### PR TITLE
Improve runtime loop, storage safety, and configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ GoWorkerAI is an AI-powered worker builder in Go. It aims to help developers aut
 
 ---
 
+## ⚙️ Configuration
+
+Set environment variables to customize the model client:
+
+- `LLM_BASE_URL` – base URL for the LLM API (default `http://localhost:1234`)
+- `LLM_MODEL` – model name used for text generation
+- `LLM_EMBEDDINGS_MODEL` – embeddings model name
+
+---
+
 
 ## 👥 Collaborations
 

--- a/app/clients/discord.go
+++ b/app/clients/discord.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -104,7 +105,9 @@ func (c *DiscordClient) onMessageCreate(s *discordgo.Session, m *discordgo.Messa
 	if m.Author.ID != os.Getenv("DISCORD_ADMIN") {
 		return
 	}
-	c.runtime.SaveEventOnHistory(m.Content)
+	if err := c.runtime.SaveEventOnHistory(context.Background(), m.Content); err != nil {
+		log.Printf("⚠️ Error saving event: %v", err)
+	}
 	if strings.HasPrefix(m.Content, "!task") {
 		parts := strings.Fields(m.Content)
 		if len(parts) < 2 {

--- a/config.go
+++ b/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"GoWorkerAI/app/clients"
 	"GoWorkerAI/app/models"
 	"GoWorkerAI/app/storage"
@@ -54,5 +56,13 @@ func getDB() storage.Interface {
 }
 
 func getModel(db storage.Interface) models.Interface {
-	return models.NewLMStudioClient(db, gptModel, embeddingModel)
+	model := os.Getenv("LLM_MODEL")
+	if model == "" {
+		model = gptModel
+	}
+	embModel := os.Getenv("LLM_EMBEDDINGS_MODEL")
+	if embModel == "" {
+		embModel = embeddingModel
+	}
+	return models.NewLMStudioClient(db, model, embModel)
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"sync"
@@ -23,7 +24,7 @@ func main() {
 		}
 		go func() {
 			defer wg.Done()
-			r.Start()
+			r.Start(context.Background())
 		}()
 	}
 	log.Println("All runtimes started. Waiting for clients indefinitely...")


### PR DESCRIPTION
## Summary
- refactor runtime event loop to block on context and events without busy waiting
- use transactional auto-increment history storage and propagate context for events
- make LLM base URL and model names configurable via environment variables

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896b1fb08c4832e93dfe56522d58240