### PR TITLE
feat: separate log files per worker

### DIFF
--- a/app/runtime/events.go
+++ b/app/runtime/events.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"GoWorkerAI/app/storage"
@@ -37,13 +36,13 @@ func (r *Runtime) SaveEventOnHistory(ctx context.Context, content string) error 
 
 func (r *Runtime) handleEvent(ev Event) {
 	msg := ev.HandlerFunc(r, ev)
-	log.Printf("🆕 New Event received: %s Task: %v\n", msg, ev.Task)
+	r.logger.Printf("🆕 New Event received: %s Task: %v\n", msg, ev.Task)
 }
 
 var EventsHandlerFuncDefault = map[string]func(r *Runtime, ev Event) string{
 	NewTask: func(r *Runtime, ev Event) string {
 		if ev.Task == nil {
-			log.Println("⚠️ NewTask called with nil task.")
+			r.logger.Println("⚠️ NewTask called with nil task.")
 			return NewTask
 		}
 
@@ -53,7 +52,7 @@ var EventsHandlerFuncDefault = map[string]func(r *Runtime, ev Event) string{
 		r.mu.Unlock()
 
 		if prevCancel != nil {
-			log.Println("🛑 Canceling current task before starting a new one.")
+			r.logger.Println("🛑 Canceling current task before starting a new one.")
 			prevCancel()
 		}
 
@@ -64,14 +63,14 @@ var EventsHandlerFuncDefault = map[string]func(r *Runtime, ev Event) string{
 		if worker != nil {
 			worker.SetTask(ev.Task)
 		} else {
-			log.Println("⚠️ No worker configured; task will not run.")
+			r.logger.Println("⚠️ No worker configured; task will not run.")
 		}
 		r.activeTask.Store(true)
 		r.mu.Unlock()
 
 		go func() {
 			if err := r.runTask(ctx); err != nil {
-				log.Printf("Error running task: %v", err)
+				r.logger.Printf("Error running task: %v", err)
 			}
 		}()
 
@@ -80,7 +79,7 @@ var EventsHandlerFuncDefault = map[string]func(r *Runtime, ev Event) string{
 
 	CancelTask: func(r *Runtime, ev Event) string {
 		if !r.activeTask.CompareAndSwap(true, false) {
-			log.Println("⚠️ No active task to cancel.")
+			r.logger.Println("⚠️ No active task to cancel.")
 			return CancelTask
 		}
 
@@ -88,7 +87,7 @@ var EventsHandlerFuncDefault = map[string]func(r *Runtime, ev Event) string{
 		r.StopRuntime()
 		r.mu.Unlock()
 
-		log.Println("🛑 Canceling active task.")
+		r.logger.Println("🛑 Canceling active task.")
 		return CancelTask
 	},
 }

--- a/app/runtime/runtime_test.go
+++ b/app/runtime/runtime_test.go
@@ -1,13 +1,15 @@
 package runtime
 
 import (
+	"io"
+	"log"
 	"testing"
 
 	"GoWorkerAI/app/tools"
 )
 
 func TestRuntimeAddTools(t *testing.T) {
-	r := NewRuntime(nil, nil, nil, nil, false)
+	r := NewRuntime(nil, nil, nil, nil, false, log.New(io.Discard, "", 0))
 	r.AddTools([]tools.Tool{{Name: "a"}, {Name: "b"}})
 	tk := r.Toolkit()
 	if len(tk) != 2 || tk["a"].Name != "a" || tk["b"].Name != "b" {
@@ -20,7 +22,7 @@ func TestRuntimeAddTools(t *testing.T) {
 }
 
 func TestRuntimeQueueEvent(t *testing.T) {
-	r := NewRuntime(nil, nil, nil, nil, false)
+	r := NewRuntime(nil, nil, nil, nil, false, log.New(io.Discard, "", 0))
 	r.QueueEvent(Event{})
 	if len(r.events) != 1 {
 		t.Fatalf("unexpected event queue length: %d", len(r.events))

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"sync"
@@ -16,17 +17,22 @@ func main() {
 	model := getModel(db)
 	clients := getClients()
 	var wg sync.WaitGroup
-	for _, worker := range customWorkers {
+	colors := []string{"\033[31m", "\033[32m", "\033[33m", "\033[34m", "\033[35m", "\033[36m"}
+	for i, worker := range customWorkers {
 		wg.Add(1)
 		toolsPreset := tools.NewToolkitFromPreset(worker.GetToolsPreset())
-		r := runtime.NewRuntime(worker, model, toolsPreset, db, worker.GetTask() != nil)
+		_, logger, err := runtime.NewWorkerLogger(fmt.Sprintf("worker_%d", i+1), colors[i%len(colors)], 10000)
+		if err != nil {
+			log.Fatalf("failed to create logger for worker %d: %v", i+1, err)
+		}
+		r := runtime.NewRuntime(worker, model, toolsPreset, db, worker.GetTask() != nil, logger)
 		for _, client := range clients {
 			client.Subscribe(r)
 		}
-		go func() {
+		go func(rt *runtime.Runtime) {
 			defer wg.Done()
-			r.Start(context.Background())
-		}()
+			rt.Start(context.Background())
+		}(r)
 	}
 	log.Println("All runtimes started. Waiting for clients indefinitely...")
 	wg.Wait()


### PR DESCRIPTION
## Summary
- add `NewWorkerLogger` for worker-specific logging with colorized console output and file storage
- wire runtimes to use dedicated loggers so each worker writes to its own log file
- update startup to create loggers and pass them to runtimes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a2700b5444832e9e31f97cd6d8ed42